### PR TITLE
only accept absolute source and target paths

### DIFF
--- a/hrsync
+++ b/hrsync
@@ -20,6 +20,18 @@ Shadow=".rsync_shadow"
 
 # Start doing things
 
+if [ "${Source:0:1}" != / ]
+then
+	echo "Source path needs to be an absolute path"
+	exit 0
+fi
+
+if [ "${Target:0:1}" != / ]
+then
+	echo "Target path needs to be an absolute path"
+	exit 0
+fi
+
 if [ -z "$2" ]
 then
 	echo "Usage:"


### PR DESCRIPTION
My first try to use `hrsync` like this:
```shell
mkdir A
mkdir B
date > A/file
./hrsync A B
```
resulted in three `--link-dest arg does not exist` errors:
```
--link-dest arg does not exist: A
building file list ... done
./
file
.rsync_shadow/
.rsync_shadow/file

Number of files: 4 (reg: 2, dir: 2)
Number of created files: 3 (reg: 2, dir: 1)
Number of deleted files: 0
Number of regular files transferred: 2
Total file size: 60 bytes
Total transferred file size: 60 bytes
Literal data: 60 bytes
Matched data: 0 bytes
File list size: 0
File list generation time: 0.001 seconds
File list transfer time: 0.000 seconds
Total bytes sent: 277
Total bytes received: 59

sent 277 bytes  received 59 bytes  672.00 bytes/sec
total size is 60  speedup is 0.18
--link-dest arg does not exist: A
--link-dest arg does not exist: B
```
I did not understand that using absolute paths like given in the help text is crucial and a must and that relative paths lead to this error.
To make this easier to spot I propose the attached patch to show an error message when a relative path is used for source or target path.