### PR TITLE
fix quoting of spaces in remote paths

### DIFF
--- a/hrsync
+++ b/hrsync
@@ -47,7 +47,7 @@ then
 	rsync -axXhHv --stats --no-inc-recursive --numeric-ids --delete --delete-after "$Source"/ "$Target"
 else
 	# remote version
-	rsync -axXhHv --stats --no-inc-recursive --numeric-ids --delete --delete-after "$Source"/ $TargetHost:"$Target"
+	rsync -axXhHv --stats --no-inc-recursive --numeric-ids --delete --delete-after "$Source"/ $TargetHost:"'$Target'"
 fi
 
 status=$?
@@ -64,7 +64,7 @@ then
 		rsync -a --delete --link-dest="$Target" --exclude="/$Shadow" "$Target/" "$Target/$Shadow"
 	else
 		# remote version
-		ssh $TargetHost "rsync -a --delete --link-dest=$Target --exclude=/$Shadow $Target/ $Target/$Shadow"
+		ssh $TargetHost "rsync -a --delete --link-dest='$Target' --exclude='/$Shadow' '$Target/' '$Target/$Shadow'"
 	fi
 fi
 


### PR DESCRIPTION
Using a pathname with a space breaks on remote execution because both `rsync` and `ssh` need an additional level of quoting.

The attached patch should fix simple cases like whitespace characters in the pathname.
More complex filenames containing `\`, `"` or `'` might still break.

For an example of the bug, see this:
```
remote $ mkdir -p "/tmp/hrsync/C D"

local $ mkdir -p "/tmp/hrsync/A B"
local $ date > "/tmp/hrsync/A B/file"
local $ ./hrsync "/tmp/hrsync/A B" "/tmp/hrsync/C D" user@remote
building file list ... done
created directory /tmp/hrsync/C
./
.rsync_shadow/
.rsync_shadow/file
file => .rsync_shadow/file

Number of files: 4 (reg: 2, dir: 2)
Number of created files: 4 (reg: 2, dir: 2)
Number of deleted files: 0
Number of regular files transferred: 1
Total file size: 60 bytes
Total transferred file size: 30 bytes
Literal data: 30 bytes
Matched data: 0 bytes
File list size: 0
File list generation time: 0.001 seconds
File list transfer time: 0.000 seconds
Total bytes sent: 225
Total bytes received: 102

sent 225 bytes  received 102 bytes  130.80 bytes/sec
total size is 60  speedup is 0.18
rsync: link_stat "/home/user/D" failed: No such file or directory (2)
rsync: change_dir "/home/user//D" failed: No such file or directory (2)
rsync: mkdir "/home/user/D/.rsync_shadow" failed: No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(674) [Receiver=3.1.1]

remote $ ls -a "/tmp/hrsync/C D"
.  ..
remote $ ls -a "/tmp/hrsync/C"
.  ..  file  .rsync_shadow
```